### PR TITLE
3: define missing specialized agent roles (US-104)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -50,5 +50,5 @@ Use this template for each new entry:
 - Context: Issue #3 (US-104) — define missing specialized agent roles for Option A refactoring epics.
 - Problem: Large roadmap tasks (Electron upgrade, test bootstrap, modularization, dependency modernization) had no designated agent boundary, making sprint decomposition ambiguous.
 - Resolution: Produced a role catalog (`docs/11_agent_role_catalog.md`) with four roles: pancake-electron-upgrader, pancake-test-bootstrapper, pancake-modularizer, pancake-dependency-modernizer. Each role has defined purpose, boundaries, inputs, outputs, and failure guard rails.
-- Rule: Research/documentation issues produce catalog or design docs only — do not create agent .md files until the role's activation sprint. Keep role boundaries single-concern.
+- Rule: Research/documentation issues produce catalog or design docs only — do not create `.agent.md` agent definition files until the role's activation sprint. Keep role boundaries single-concern.
 - Affected files: docs/11_agent_role_catalog.md, LEARNINGS.md.

--- a/docs/11_agent_role_catalog.md
+++ b/docs/11_agent_role_catalog.md
@@ -42,7 +42,7 @@ workflow for domain-specific refactoring tasks.
 #### Purpose
 
 Execute a targeted Electron version bump from the current legacy baseline to a
-supported LTS release, resolving all API-level breaking changes without changing
+currently supported/stable Electron release line, resolving all API-level breaking
 application logic or business behaviour.
 
 #### Boundaries
@@ -115,10 +115,15 @@ roles depend on.
 - Validation contract update if test command changes
 
 **Out of scope:**
+- CI/test-runner alignment necessary for Jest (for example, updating the Node.js
+  version and test command in `.travis.yml` or equivalent so the test suite runs)
+
+**Out of scope:**
 - Production source code changes (tests only)
 - Electron upgrade (handled by Role 1)
 - Comprehensive end-to-end or integration test suites
-- CI pipeline changes beyond updating the validation contract doc
+- Major CI pipeline redesign beyond minimal updates such as Node version or
+  test command changes already captured in the validation contract doc
 
 #### Required inputs
 


### PR DESCRIPTION
Closes #3. Adds docs/11_agent_role_catalog.md: role catalog for four specialized agents required by Option A refactoring epics (E2-E5). Roles: pancake-electron-upgrader (E3/Sprint5), pancake-test-bootstrapper (E2/Sprint2), pancake-modularizer (E4/Sprint6-7), pancake-dependency-modernizer (E5/Sprint8). Each role defines purpose, boundaries, inputs, outputs, and failure guard rails. Agent .md files deferred to activation sprints. LEARNINGS.md updated.