### PR TITLE
US-303: Add Undo and Utility Test Coverage

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -75,6 +75,14 @@ Using `require(configPath)` caches parsed JSON and can hide runtime changes in r
 Delegating directly to `paper.loadPBP(filePath)` without checking file readability obscures missing/unreadable path errors.
 - Rule: For open flow unit boundaries, check `existsSync` and `readFileSync` first, then call parser/loader; catch and surface errors consistently.
 
+**Undo helper can be tested with plain project/view stubs, no canvas runtime**
+`helper.undo.js` state operations rely on `project.exportJSON/importJSON`, layer activation, and `view.update` calls, not on actual Paper.js rendering.
+- Rule: Unit tests for undo should stub `paper.project`, `paper.view`, and selection helpers (`deselect/reselect/emptyProject`) with plain objects.
+
+**Utility helper tests should mock top-level optional dependencies even when testing pure functions**
+`helper.utils.js` requires modules like `electron-canvas-to-buffer`, `fs-plus`, and `progress-promise` at helper factory creation time.
+- Rule: In Jest, mock these modules up front so pure utility function tests (`rgbToHex`, `colorStringToArray`, `fitScale`, etc.) remain isolated and runtime-agnostic.
+
 ---
 
 ## Documentation / Markdown

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,17 +91,18 @@ environment without any Electron or Paper.js mocking:
 
 ## Coverage Baseline
 
-Current baseline (updated Sprint 3, US-302):
+Current baseline (updated Sprint 3, US-303):
 
 | Metric | Baseline |
 |--------|----------|
-| Statements | 73.89% |
-| Branches | 65.94% |
-| Functions | 85.10% |
-| Lines | 76.51% |
+| Statements | 52.98% |
+| Branches | 45.38% |
+| Functions | 63.33% |
+| Lines | 54.29% |
 
 Previous baseline (Sprint 2, US-202): ~0% (sample test only)
 
-Coverage improvement reflects addition of US-301 GCODE tests and US-302 file
-I/O and settings persistence tests. Run `npm run jest -- --coverage` to capture
-the current baseline and compare against future sprint work.
+Coverage now includes additional helper-module measurement from US-303
+(`helper.undo.js`, `helper.utils.js`) in addition to US-301/US-302 tests.
+Run `npm run jest -- --coverage` to capture the current baseline and compare
+against future sprint work.

--- a/tests/unit/helpers/helper.undo.test.js
+++ b/tests/unit/helpers/helper.undo.test.js
@@ -1,0 +1,143 @@
+/**
+ * @file Unit tests for helper.undo.js
+ *
+ * Scope: verifies undo stack state push/pop behavior, stack limits, and edge
+ * cases using plain object fixtures (no Electron runtime, no canvas runtime).
+ */
+'use strict';
+
+const createUndoHelper = require('../../../src/helpers/helper.undo');
+
+describe('helper.undo', () => {
+  let paper;
+  let project;
+  let view;
+  let undo;
+
+  beforeEach(() => {
+    project = {
+      exportJSON: jest.fn(() => JSON.stringify({ stamp: Date.now() })),
+      importJSON: jest.fn(),
+      layers: [
+        { children: [] },
+        { activate: jest.fn() }
+      ]
+    };
+
+    view = {
+      update: jest.fn()
+    };
+
+    paper = {
+      project: project,
+      view: view,
+      deselect: jest.fn(),
+      reselect: jest.fn(),
+      emptyProject: jest.fn(),
+      imageLayer: null,
+      mainLayer: null,
+      traceImage: null
+    };
+
+    undo = createUndoHelper(paper);
+  });
+
+  /**
+   * Verifies helper initialization captures initial state.
+   * Expected: one state exists at index 0.
+   */
+  test('captures initial state on helper creation', () => {
+    expect(undo.index).toBe(0);
+    expect(undo.data.length).toBe(1);
+    expect(project.exportJSON).toHaveBeenCalled();
+  });
+
+  /**
+   * Verifies push behavior and stack trimming.
+   * Expected: new states are unshifted and stack obeys undoLevels limit.
+   */
+  test('pushes states and trims stack to undoLevels', () => {
+    undo.options.undoLevels = 3;
+
+    undo.stateChanged();
+    undo.stateChanged();
+    undo.stateChanged();
+    undo.stateChanged();
+
+    expect(undo.data.length).toBe(3);
+    expect(undo.index).toBe(0);
+  });
+
+  /**
+   * Verifies backward undo behavior.
+   * Expected: goBack moves index and restores corresponding prior state.
+   */
+  test('goBack restores previous states in order', () => {
+    let counter = 0;
+    project.exportJSON.mockImplementation(() => JSON.stringify({ state: counter++ }));
+
+    undo.stateChanged();
+    undo.stateChanged();
+
+    undo.goBack();
+
+    expect(undo.index).toBe(1);
+    expect(project.importJSON).toHaveBeenCalledWith(undo.data[1]);
+    expect(view.update).toHaveBeenCalled();
+  });
+
+  /**
+   * Verifies multiple consecutive undos stop at stack boundary.
+   * Expected: index does not exceed last available state.
+   */
+  test('supports multiple consecutive undos without overrun', () => {
+    undo.stateChanged();
+    undo.stateChanged();
+
+    undo.goBack();
+    undo.goBack();
+    undo.goBack();
+
+    expect(undo.index).toBe(undo.data.length - 1);
+  });
+
+  /**
+   * Verifies forward redo behavior after undo.
+   * Expected: goForward decreases index until current tip is reached.
+   */
+  test('goForward returns toward latest state after undo', () => {
+    undo.stateChanged();
+    undo.stateChanged();
+
+    undo.goBack();
+    undo.goForward();
+
+    expect(undo.index).toBe(0);
+  });
+
+  /**
+   * Verifies empty stack edge-case safety.
+   * Expected: undo on empty stack does not throw and does not move index.
+   */
+  test('goBack on empty stack is a no-op', () => {
+    undo.data = [];
+    undo.index = 0;
+
+    expect(() => undo.goBack()).not.toThrow();
+    expect(undo.index).toBe(0);
+  });
+
+  /**
+   * Verifies clearState semantics.
+   * Expected: clear resets stack and captures a new base state.
+   */
+  test('clearState resets history and stores one fresh state', () => {
+    undo.stateChanged();
+    undo.stateChanged();
+
+    undo.clearState();
+
+    expect(undo.index).toBe(0);
+    expect(undo.data.length).toBe(1);
+  });
+});

--- a/tests/unit/helpers/helper.utils.test.js
+++ b/tests/unit/helpers/helper.utils.test.js
@@ -1,0 +1,105 @@
+/**
+ * @file Unit tests for helper.utils.js
+ *
+ * Scope: verifies representative high-reuse utility functions with boundary
+ * inputs and deterministic input/output assertions.
+ */
+'use strict';
+
+jest.mock('electron-canvas-to-buffer', () => jest.fn());
+jest.mock('fs-plus', () => ({ writeFile: jest.fn() }));
+jest.mock('progress-promise', () => function ProgressPromise(executor) {
+  return new Promise((resolve, reject) => executor(resolve, reject, () => {}));
+});
+
+const createUtils = require('../../../src/helpers/helper.utils');
+
+describe('helper.utils', () => {
+  let paper;
+  let utils;
+
+  beforeEach(() => {
+    paper = {
+      Group: function MockGroup() {},
+      utils: {}
+    };
+    utils = createUtils(paper);
+    paper.utils = utils;
+  });
+
+  /**
+   * Verifies rgbToHex conversion and passthrough boundaries.
+   * Expected: RGB string converts to HEX, non-RGB input returns unchanged.
+   */
+  test('rgbToHex converts rgb values and passes through non-rgb strings', () => {
+    expect(utils.rgbToHex('rgb(255, 0, 16)')).toBe('#ff0010');
+    expect(utils.rgbToHex('')).toBe('');
+    expect(utils.rgbToHex('#00ff00')).toBe('#00ff00');
+  });
+
+  /**
+   * Verifies colorStringToArray boundary parsing.
+   * Expected: supports rgb/hex input and returns null for invalid values.
+   */
+  test('colorStringToArray handles rgb, hex, and invalid inputs', () => {
+    expect(utils.colorStringToArray('rgb(1, 2, 3)')).toEqual([1, 2, 3]);
+    expect(utils.colorStringToArray('#03F')).toEqual([0, 51, 255]);
+    expect(utils.colorStringToArray(undefined)).toBeNull();
+    expect(utils.colorStringToArray('not-a-color')).toBeNull();
+  });
+
+  /**
+   * Verifies color model conversion boundaries.
+   * Expected: null inputs return false and normal inputs map deterministically.
+   */
+  test('rgbToHSL and rgbToYUV handle null and valid values', () => {
+    expect(utils.rgbToHSL(null)).toBe(false);
+    expect(utils.rgbToYUV(null)).toBe(false);
+
+    const hslRed = utils.rgbToHSL([255, 0, 0]);
+    expect(hslRed[0]).toBeCloseTo(0);
+    expect(hslRed[1]).toBeCloseTo(1);
+
+    expect(utils.rgbToYUV([0, 0, 0])).toEqual([0, 128, 128]);
+  });
+
+  /**
+   * Verifies duplication layout behavior for expected counts and boundaries.
+   * Expected: empty trace bounds return defaults, count variants return positions.
+   */
+  test('getDuplicationLayout returns safe defaults and valid layouts', () => {
+    const griddle = { width: 400, height: 200 };
+
+    expect(utils.getDuplicationLayout(4, { width: 0, height: 10 }, griddle)).toEqual({
+      scale: 1,
+      positions: []
+    });
+
+    const layout2 = utils.getDuplicationLayout(2, { width: 100, height: 80 }, griddle);
+    expect(layout2.positions.length).toBe(2);
+    expect(layout2.scale).toBeGreaterThan(0);
+
+    const layout8 = utils.getDuplicationLayout(8, { width: 100, height: 300 }, griddle);
+    expect(layout8.positions.length).toBe(8);
+    expect(layout8.scale).toBeGreaterThan(0);
+  });
+
+  /**
+   * Verifies fitScale behavior with explicit fill factors.
+   * Expected: uses smaller axis scale and calls object.scale once.
+   */
+  test('fitScale computes minimum axis scale and applies it', () => {
+    const target = {
+      bounds: { width: 100, height: 50 },
+      scale: jest.fn()
+    };
+    const view = {
+      bounds: { width: 200, height: 80 }
+    };
+
+    const applied = utils.fitScale(target, view, 1, 1);
+
+    expect(applied).toBeCloseTo(1.6);
+    expect(target.scale).toHaveBeenCalledWith(applied);
+  });
+});


### PR DESCRIPTION
## Overview

Closes #19

Adds isolated unit test coverage for undo stack behavior and representative utility helper functions, with boundary input assertions and no Electron runtime dependency.

## Changes

- Added undo helper tests:
  - tests/unit/helpers/helper.undo.test.js
  - Covers state push/pop behavior, stack limits, clear/reset, empty stack and consecutive undo edge cases
- Added utility helper tests:
  - tests/unit/helpers/helper.utils.test.js
  - Covers representative high-reuse functions (gbToHex, colorStringToArray, gbToHSL, gbToYUV, getDuplicationLayout, itScale) including boundary inputs
- Updated testing docs and learnings:
  - tests/README.md baseline updated
  - LEARNINGS.md updated with US-303 testing guidance

## Validation

- npm install
- npm test
- npx jest --coverage

All checks passed locally.
