### PR TITLE
45: Fix cross-version PBP scaling and save regression

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -23,6 +23,23 @@ Refactoring surrounding code while fixing lint violations risks introducing new 
 Skipping `npm install` causes false-positive test passes on a stale dependency tree.
 - Rule: Always run `npm install` → `npm test` (lint + jest). Run `npm run smoke` only for startup-affecting changes; document the decision in the stage checkpoint.
 
+**Validation docs should not hardcode passing test counts**
+Test suite totals change as coverage grows, and stale counts make validation instructions look broken even when the suite is green.
+- Rule: In docs and prompts, say the full suite must pass instead of pinning an exact `N/N` unless the count is part of the thing being tested.
+
+---
+
+## Electron Context Isolation (Sprint 5 Migration)
+
+**contextIsolation and nodeIntegration conflict**
+Setting both `contextIsolation: true` and `nodeIntegration: true` in webPreferences causes "cannot assign to read-only property" errors when preload tries to attach bridges to the window object.
+- Rule: In webPreferences, set `contextIsolation: true` and `nodeIntegration: false` (exclusive pair for security).
+
+**Preload bridge exposure condition**
+The preload bridge should check if `contextBridge.exposeInMainWorld` exists, not probe `process.contextIsolated` (the property may be inaccessible or unreliable in preload context).
+- Rule: Use `if (contextBridge && typeof contextBridge.exposeInMainWorld === 'function') { contextBridge.exposeInMainWorld(...) }` pattern.
+- Consequence: Remove fallback code that tries to `window.appBridge = ...` when context isolation is active (it will fail).
+
 ---
 
 ## PowerShell / Windows
@@ -30,6 +47,36 @@ Skipping `npm install` causes false-positive test passes on a stale dependency t
 **Electron cleanup: use `taskkill /T`, not `Stop-Process`**
 npm on Windows creates a process tree; stopping only the parent leaves Electron child processes running.
 - Rule: In smoke-check and supervision scripts, clean up with `taskkill /F /T /PID`.
+
+---
+
+## Drawing Canvas & Zoom
+
+**Paper.js stroke scaling with zoom**
+By default, Paper.js scales all stroke widths when the view zooms. For drawing apps, this makes lines appear thinner when zooming in and thicker when zooming out (opposite of visual expectation).
+- Rule: Set `view.strokeScaling = false` in PaperScript initialization to keep strokes at consistent pixel size regardless of zoom level.
+- Implementation: Added in [src/editor.ps.js](src/editor.ps.js#L13-L14) after `paper.settings` initialization.
+- Test: Draw a line, zoom view fully in/out - stroke width should remain visually consistent.
+
+**Electron beforeunload for unsaved changes**
+**SVG naturalWidth is unstable across Chromium versions — use viewBox constants**
+`$img[0].naturalWidth` for an SVG `<img>` without explicit `width`/`height` attributes returns
+`300` (CSS default) in Chrome ≤ 66 and the SVG viewBox width in Chrome 84+.
+PancakePainter used this as the zoom denominator in `syncViewToScale`, so upgrading Electron
+produced a ~4.8× coordinate-space shift that corrupted cross-version `.pbp` geometry.
+- Fix: expose `griddleSvgNaturalSize: { width: 1437.2, height: 758.8 }` in `getAppConstants()`
+	and use it instead of `$griddle[0].naturalWidth/naturalHeight` in `app.js`.
+- Migration: `getPBP()` stores `project.data.ppScaleDenominator`; `loadPBP()` scales layers
+	when the saved denominator differs from the current one.  Legacy files (no metadata, all
+	coordinates < 350 units) are auto-detected and scaled up by 1437.2 / 300.
+- Test: `main.config.test.js` verifies the constant value, migration factor, and coordinate width.
+
+**Electron beforeunload for unsaved changes**
+Using `window.onbeforeunload` with `return checkFileStatus()` blocks window close even when the user doesn't want to save. The function must return `undefined` (or nothing) to allow close, not `true`.
+- Rule: In `beforeunload`, call dialog handlers but return `undefined` to allow Electron's close event to proceed.
+- Anti-pattern: `return true` or `return checkFileStatus()` when checkFileStatus returns boolean - this prevents close.
+- Implementation: Modified [src/app.js](src/app.js#L896-L907) to allow close while still showing save dialog on unsaved changes.
+- Test: Make unsaved changes, click X button - should show save dialog, then close successfully.
 
 **`$ErrorActionPreference = 'Stop'` makes `Write-Error` terminate before `exit`**
 `Write-Error` throws an unhandled exception under `Stop` preference, bypassing the intended `exit 1` and producing a verbose trace instead of a clean message.
@@ -138,3 +185,26 @@ A pass-through shim (`return require(moduleName)`) restores broad Node/Electron 
 **Platform-specific module selection in tests must be deterministic**
 Modules that branch on `process.platform` at require-time can make tests pass on one OS and fail on another.
 - Rule: For Jest tests covering platform-gated modules, set `process.platform` before `require(...)`, restore it in `finally`, and `jest.resetModules()` to avoid cross-test leakage.
+
+## Toolbar & CSS Sprites
+
+**CSS sprite positioning requires CSS-driven background-position, not inline style assignments**
+The original toolbar used ackground-position-x and ackground-position-y via CSS rules indexed by active tool and color state. When refactoring replaced this with inline ackground-size: 100% 400% and ackground-position: center top, the entire sprite (all 4 color variants stacked) displayed in each toolbar cell.
+- Root cause: Inline styles override CSS specificity; removing the CSS class-based selector left only the envelope size.
+- Rule: For color-change tools, use pure ackground-image in DOM and let CSS drivers handle background-position-x (active state) and background-position-y (color variant selection via parent class).
+
+**i18n text lookups must include fallback strings when locales are incomplete**
+The fill tool warning/error toasts displayed empty orange boxes when i18n returned the key itself or an empty string.
+- Rule: Create a helper 	(key, fallback) that checks truthy return and defaults to fallback English text.
+- Fallbacks: "Error creating fill.", "Cannot flood fill without at least one closed line.", "Cannot flood fill on top of an existing line.", "Flood fill out of bounds.", "Flood fill area is not closed."
+
+**Flood-fill alpha threshold must be low for anti-aliased strokes**
+Setting alphaBitmapThreshold to 150 means semi-transparent anti-aliased pixels at stroke edges are not included in the rasterized boundary grid, causing false "not closed" detection.
+- Rule: Use alpha threshold 10-30 for hand-drawn shapes to catch anti-aliased edges.
+- Implementation: Changed from 150 to 10 in tool.fill.js line 28.
+
+**Flood-fill grid dimensions and boundary checks must use exclusive upper bounds**
+The ndarray grid is allocated with shape [w, h] (indices 0 to w-1, 0 to h-1). Boundary checks must use >= instead of >.
+- Grid: ndarray(..., [w, h])
+- Check: if (x >= w || y >= h) return; (not x > w)
+

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -58,7 +58,6 @@ By default, Paper.js scales all stroke widths when the view zooms. For drawing a
 - Implementation: Added in [src/editor.ps.js](src/editor.ps.js#L13-L14) after `paper.settings` initialization.
 - Test: Draw a line, zoom view fully in/out - stroke width should remain visually consistent.
 
-**Electron beforeunload for unsaved changes**
 **SVG naturalWidth is unstable across Chromium versions — use viewBox constants**
 `$img[0].naturalWidth` for an SVG `<img>` without explicit `width`/`height` attributes returns
 `300` (CSS default) in Chrome ≤ 66 and the SVG viewBox width in Chrome 84+.
@@ -189,13 +188,13 @@ Modules that branch on `process.platform` at require-time can make tests pass on
 ## Toolbar & CSS Sprites
 
 **CSS sprite positioning requires CSS-driven background-position, not inline style assignments**
-The original toolbar used ackground-position-x and ackground-position-y via CSS rules indexed by active tool and color state. When refactoring replaced this with inline ackground-size: 100% 400% and ackground-position: center top, the entire sprite (all 4 color variants stacked) displayed in each toolbar cell.
+The original toolbar used background-position-x and background-position-y via CSS rules indexed by active tool and color state. When refactoring replaced this with inline background-size: 100% 400% and background-position: center top, the entire sprite (all 4 color variants stacked) displayed in each toolbar cell.
 - Root cause: Inline styles override CSS specificity; removing the CSS class-based selector left only the envelope size.
-- Rule: For color-change tools, use pure ackground-image in DOM and let CSS drivers handle background-position-x (active state) and background-position-y (color variant selection via parent class).
+- Rule: For color-change tools, use pure background-image in DOM and let CSS drivers handle background-position-x (active state) and background-position-y (color variant selection via parent class).
 
 **i18n text lookups must include fallback strings when locales are incomplete**
 The fill tool warning/error toasts displayed empty orange boxes when i18n returned the key itself or an empty string.
-- Rule: Create a helper 	(key, fallback) that checks truthy return and defaults to fallback English text.
+- Rule: Create a helper (key, fallback) that checks truthy return and defaults to fallback English text.
 - Fallbacks: "Error creating fill.", "Cannot flood fill without at least one closed line.", "Cannot flood fill on top of an existing line.", "Flood fill out of bounds.", "Flood fill area is not closed."
 
 **Flood-fill alpha threshold must be low for anti-aliased strokes**

--- a/src/app.js
+++ b/src/app.js
@@ -261,6 +261,27 @@ function loadRendererModule(request, parentFilePath) {
 
 // Helper for file I/O operations (inline since renderer cannot use require)
 var fileIO = (function() {
+  function renderToastMessage(i18n, key, fileName, fallbackTemplate) {
+    var vars = { file: fileName };
+    var translated = i18n.t(key, vars);
+
+    if (translated && translated !== key) {
+      return translated;
+    }
+
+    var fallback = fallbackTemplate.replace('{{file}}', fileName || '');
+    translated = i18n.t(key, {
+      file: fileName,
+      defaultValue: fallback
+    });
+
+    if (translated && translated !== key) {
+      return translated;
+    }
+
+    return fallback;
+  }
+
   function normalizeProjectPath(filePath) {
     if (!filePath) return '';
     if (bridge.path.extname(filePath).toLowerCase() !== '.pbp') {
@@ -280,15 +301,25 @@ var fileIO = (function() {
     if (!targetPath) return false;
 
     currentFile.path = targetPath;
-  currentFile.name = bridge.path.basename(targetPath);
+    currentFile.name = bridge.path.basename(targetPath);
 
     try {
       fs.writeFileSync(currentFile.path, paper.getPBP());
-      toastr.success(i18n.t('file.note', { file: currentFile.name }));
+      toastr.success(renderToastMessage(
+        i18n,
+        'file.note',
+        currentFile.name,
+        'Saved {{file}}.'
+      ));
       currentFile.changed = false;
       return true;
     } catch (e) {
-      toastr.error(i18n.t('file.error', { file: currentFile.name }));
+      toastr.error(renderToastMessage(
+        i18n,
+        'file.error',
+        currentFile.name,
+        'Could not save {{file}}.'
+      ));
       return false;
     }
   }
@@ -303,7 +334,12 @@ var fileIO = (function() {
     var parsedName = bridge.path.basename(filePath || '');
 
     if (!filePath || !fs.existsSync(filePath)) {
-      toastr.error(i18n.t('file.error', { file: parsedName }));
+      toastr.error(renderToastMessage(
+        i18n,
+        'file.error',
+        parsedName,
+        'Could not open {{file}}.'
+      ));
       return false;
     }
 
@@ -315,7 +351,12 @@ var fileIO = (function() {
       return true;
     } catch (e) {
       var fileName = bridge.path.basename(filePath);
-      toastr.error(i18n.t('file.error', { file: fileName }));
+      toastr.error(renderToastMessage(
+        i18n,
+        'file.error',
+        fileName,
+        'Could not open {{file}}.'
+      ));
       return false;
     }
   }
@@ -490,8 +531,13 @@ function initEditor() {
     }
 
     scale = {};
-    scale.x = ($griddle.width()) / $griddle[0].naturalWidth;
-    scale.y = ($griddle.height()) / $griddle[0].naturalHeight;
+    // Use fixed SVG viewBox dimensions instead of DOM naturalWidth, which
+    // is unstable across Chromium versions (300 in Chrome ≤ 66, viewBox
+    // value in Chrome 84+), causing a ~4.8× coordinate-space mismatch.
+    scale.x = ($griddle.width()) /
+      ac.griddleSvgNaturalSize.width;
+    scale.y = ($griddle.height()) /
+      ac.griddleSvgNaturalSize.height;
 
     scale = (scale.x < scale.y ? scale.x : scale.y);
 

--- a/src/editor.ps.js
+++ b/src/editor.ps.js
@@ -9,10 +9,6 @@
 
 paper.strokeWidth = 1; // Match original visual line thickness
 paper.settings.handleSize = 10;
-// Prevent stroke widths from visually scaling with the view zoom level.
-// Without this flag, strokes appear thinner when zoomed in (and thicker
-// when zoomed out), which is the opposite of the expected behaviour.
-view.strokeScaling = false;
 
 // Layer Management (custom vars)
 paper.imageLayer = project.getActiveLayer(); // Behind the active layer

--- a/src/editor.ps.js
+++ b/src/editor.ps.js
@@ -33,9 +33,6 @@ paper.pancakeCurrentShade = 0;
 var toolPen = require('./tools/tool.pen')(paper);
 var toolFill = require('./tools/tool.fill')(paper); /* jshint ignore:line */
 var toolSelect = require('./tools/tool.select')(paper);
-console.log('[Editor] tools registered', _.map(paper.tools, function(tool) {
-  return tool.key;
-}));
 
 // Load Helpers
 // TODO: Load via files in dir, API style.
@@ -369,5 +366,4 @@ paper.loadPBP = function(filePath){
 
 
 // Editor should be done loading, trigger loadInit
-console.log('[Editor] load complete, invoking editorLoadedInit');
 editorLoadedInit();

--- a/src/editor.ps.js
+++ b/src/editor.ps.js
@@ -7,10 +7,12 @@
    Raster, Group, Point, Layer, path, fs, editorLoadedInit
  */
 
-var dataURI = require('datauri');
-
-paper.strokeWidth = 5; // Custom
+paper.strokeWidth = 1; // Match original visual line thickness
 paper.settings.handleSize = 10;
+// Prevent stroke widths from visually scaling with the view zoom level.
+// Without this flag, strokes appear thinner when zoomed in (and thicker
+// when zoomed out), which is the opposite of the expected behaviour.
+view.strokeScaling = false;
 
 // Layer Management (custom vars)
 paper.imageLayer = project.getActiveLayer(); // Behind the active layer
@@ -31,17 +33,42 @@ paper.pancakeCurrentShade = 0;
 var toolPen = require('./tools/tool.pen')(paper);
 var toolFill = require('./tools/tool.fill')(paper); /* jshint ignore:line */
 var toolSelect = require('./tools/tool.select')(paper);
+console.log('[Editor] tools registered', _.map(paper.tools, function(tool) {
+  return tool.key;
+}));
 
 // Load Helpers
 // TODO: Load via files in dir, API style.
-_.each(['undo', 'clipboard', 'utils', 'autotrace'], function(helperName) {
-  if (helperName === 'autotrace') {
-    paper[helperName] = require('./helpers/helper.' + helperName)(paper, {
+_.each(['undo', 'clipboard'], function(helperName) {
+  paper[helperName] = require('./helpers/helper.' + helperName)(paper);
+});
+
+Object.defineProperty(paper, 'utils', {
+  configurable: true,
+  get: function() {
+    var utils = require('./helpers/helper.utils')(paper);
+    Object.defineProperty(paper, 'utils', {
+      configurable: true,
+      value: utils,
+      writable: true
+    });
+    return utils;
+  }
+});
+
+Object.defineProperty(paper, 'autotrace', {
+  configurable: true,
+  get: function() {
+    var autotrace = require('./helpers/helper.autotrace')(paper, {
       appPath: app.getAppPath(),
       tempPath: app.getPath('temp')
     });
-  } else {
-    paper[helperName] = require('./helpers/helper.' + helperName)(paper);
+    Object.defineProperty(paper, 'autotrace', {
+      configurable: true,
+      value: autotrace,
+      writable: true
+    });
+    return autotrace;
   }
 });
 
@@ -50,12 +77,24 @@ paper.setCursor = function(type) {
   if (!type) type = 'default';
 };
 
+paper.syncViewToScale = function(nextScale) {
+  if (!nextScale) {
+    return;
+  }
+
+  view.zoom = nextScale;
+
+  // Keep the project origin pinned to the top-left of the printable area.
+  var corner = view.viewToProject(new Point(0, 0));
+  view.scrollBy(new Point(0, 0).subtract(corner));
+  view.update();
+};
+
 function onResize(event) { /* jshint ignore:line */
-  // Ensure paper project view retains correct scaling and position.
-  view.zoom = scale;
-  var corner = view.viewToProject(new Point(0,0));
-  view.scrollBy(new Point(0,0).subtract(corner));
+  paper.syncViewToScale(scale);
 }
+
+view.onResize = onResize;
 
 // Initialize (or edit) an image import for tracing on top of
 paper.initImageImport = function() {
@@ -77,7 +116,7 @@ paper.initImageImport = function() {
 
       paper.imageLayer.activate(); // Draw the raster to the image layer
         var img = new Raster({
-          source: dataURI(filePath[0]),
+          source: encodeURI('file:///' + filePath[0].replace(/\\/g, '/')),
           position: view.center
         });
         // The raster MUST be in a group to alleviate coord & scaling issues.
@@ -236,6 +275,13 @@ paper.handleClipboard = function(op) {
 // Render the text/SVG for the pancakebot project files
 paper.getPBP = function(){
   paper.deselect(); // Don't export with something selected!
+  // Embed the coordinate-space denominator so future loaders can detect and
+  // migrate files from a different Electron/Chromium version.
+  if (!project.data) {
+    project.data = {};
+  }
+  project.data.ppScaleDenominator =
+    app.constants.griddleSvgNaturalSize.width;
   return project.exportJSON();
 };
 
@@ -272,6 +318,42 @@ paper.loadPBP = function(filePath){
   paper.imageLayer = project.layers[0];
   paper.mainLayer = project.layers[1];
 
+  // Migrate coordinate space for files saved with a different scale
+  // denominator.  Legacy builds (Electron ≤ 3, Chromium ≤ 66) used
+  // naturalWidth = 300, giving a ~4.8× mismatch versus the current
+  // build which anchors on the SVG viewBox width (1437.2).
+  var currentDenominator =
+    app.constants.griddleSvgNaturalSize.width;
+  var savedDenominator =
+    project.data && project.data.ppScaleDenominator;
+
+  if (!savedDenominator) {
+    // No metadata: attempt heuristic detection.
+    // Legacy space ≈ 262 units wide; current ≈ 1255.
+    // Threshold of 350 separates them without false positives.
+    var LEGACY_SCALE_DENOMINATOR = 300;
+    var LEGACY_COORD_THRESHOLD = 350;
+    var bounds = paper.mainLayer.bounds;
+    if (bounds && bounds.width > 0 &&
+        bounds.width < LEGACY_COORD_THRESHOLD) {
+      savedDenominator = LEGACY_SCALE_DENOMINATOR;
+    }
+  }
+
+  if (savedDenominator &&
+      Math.abs(savedDenominator - currentDenominator) > 0.5) {
+    // Scale layers from the saved space into the current one.
+    var migrationFactor = currentDenominator / savedDenominator;
+    var origin = new Point(0, 0);
+    paper.mainLayer.scale(migrationFactor, origin);
+    paper.imageLayer.scale(migrationFactor, origin);
+    console.log(
+      '[Editor] PBP migration: ' +
+      savedDenominator + ' -> ' + currentDenominator +
+      ' (x' + migrationFactor.toFixed(4) + ')'
+    );
+  }
+
   paper.mainLayer.activate();
 
   // Reinstate traceImage, if any.
@@ -287,4 +369,5 @@ paper.loadPBP = function(filePath){
 
 
 // Editor should be done loading, trigger loadInit
+console.log('[Editor] load complete, invoking editorLoadedInit');
 editorLoadedInit();

--- a/src/helpers/helper.file-io.js
+++ b/src/helpers/helper.file-io.js
@@ -5,6 +5,27 @@
 
 var path = require('path');
 
+function renderToastMessage(i18n, key, fileName, fallbackTemplate) {
+  var vars = { file: fileName };
+  var translated = i18n.t(key, vars);
+
+  if (translated && translated !== key) {
+    return translated;
+  }
+
+  var fallback = fallbackTemplate.replace('{{file}}', fileName || '');
+  translated = i18n.t(key, {
+    file: fileName,
+    defaultValue: fallback
+  });
+
+  if (translated && translated !== key) {
+    return translated;
+  }
+
+  return fallback;
+}
+
 function normalizeProjectPath(filePath) {
   if (!filePath) return '';
   if (path.extname(filePath).toLowerCase() !== '.pbp') {
@@ -28,11 +49,21 @@ function saveProjectFile(options) {
 
   try {
     fs.writeFileSync(currentFile.path, paper.getPBP());
-    toastr.success(i18n.t('file.note', { file: currentFile.name }));
+    toastr.success(renderToastMessage(
+      i18n,
+      'file.note',
+      currentFile.name,
+      'Saved {{file}}.'
+    ));
     currentFile.changed = false;
     return true;
   } catch (e) {
-    toastr.error(i18n.t('file.error', { file: currentFile.name }));
+    toastr.error(renderToastMessage(
+      i18n,
+      'file.error',
+      currentFile.name,
+      'Could not save {{file}}.'
+    ));
     return false;
   }
 }
@@ -47,7 +78,12 @@ function openProjectFile(options) {
   var parsedName = path.parse(filePath || '').base;
 
   if (!filePath || !fs.existsSync(filePath)) {
-    toastr.error(i18n.t('file.error', { file: parsedName }));
+    toastr.error(renderToastMessage(
+      i18n,
+      'file.error',
+      parsedName,
+      'Could not open {{file}}.'
+    ));
     return false;
   }
 
@@ -58,7 +94,12 @@ function openProjectFile(options) {
     currentFile.changed = false;
     return true;
   } catch (e) {
-    toastr.error(i18n.t('file.error', { file: path.parse(filePath).base }));
+    toastr.error(renderToastMessage(
+      i18n,
+      'file.error',
+      path.parse(filePath).base,
+      'Could not open {{file}}.'
+    ));
     return false;
   }
 }

--- a/src/helpers/helper.main-config.js
+++ b/src/helpers/helper.main-config.js
@@ -16,14 +16,14 @@ function getAppConstants() {
       width: 507.5,
       height: 267.7
     },
-      // Intrinsic dimensions from the griddle SVG viewBox.
-      // Using fixed constants avoids the Chromium-version-dependent
-      // naturalWidth value for SVGs without explicit size attributes.
-      griddleSvgNaturalSize: {
-        width: 1437.2,
-        height: 758.8
-      },
-      printableArea: {
+    // Intrinsic dimensions from the griddle SVG viewBox.
+    // Using fixed constants avoids the Chromium-version-dependent
+    // naturalWidth value for SVGs without explicit size attributes.
+    griddleSvgNaturalSize: {
+      width: 1437.2,
+      height: 758.8
+    },
+    printableArea: {
       offset: {
         left: 36.22,
         top: 34.77,

--- a/src/helpers/helper.main-config.js
+++ b/src/helpers/helper.main-config.js
@@ -16,7 +16,14 @@ function getAppConstants() {
       width: 507.5,
       height: 267.7
     },
-    printableArea: {
+      // Intrinsic dimensions from the griddle SVG viewBox.
+      // Using fixed constants avoids the Chromium-version-dependent
+      // naturalWidth value for SVGs without explicit size attributes.
+      griddleSvgNaturalSize: {
+        width: 1437.2,
+        height: 758.8
+      },
+      printableArea: {
       offset: {
         left: 36.22,
         top: 34.77,

--- a/tests/unit/helpers/file.io.test.js
+++ b/tests/unit/helpers/file.io.test.js
@@ -100,6 +100,32 @@ describe('helper.file-io', () => {
   });
 
   /**
+   * Verifies save error fallback messaging when i18n key is missing.
+   * Expected: toast receives a non-empty human-readable fallback message.
+   */
+  test('saveProjectFile uses fallback toast message when translation is empty', () => {
+    fsMock.writeFileSync.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    i18nMock.t.mockImplementation(() => '');
+
+    const success = fileIO.saveProjectFile({
+      fs: fsMock,
+      paper: paperMock,
+      toastr: toastrMock,
+      i18n: i18nMock,
+      currentFile: currentFile,
+      filePath: 'C:/tmp/new-design.pbp'
+    });
+
+    expect(success).toBe(false);
+    expect(toastrMock.error).toHaveBeenCalledWith(
+      expect.stringContaining('Could not save')
+    );
+  });
+
+  /**
    * Verifies open behavior for missing file paths.
    * Expected: missing file is rejected with user-facing error.
    */

--- a/tests/unit/helpers/main.config.test.js
+++ b/tests/unit/helpers/main.config.test.js
@@ -67,4 +67,63 @@ describe('helper.main-config', () => {
     expect(defaults).toHaveProperty('useshortest');
     expect(defaults).toHaveProperty('uselinefill');
   });
+
+  /**
+   * Verifies griddleSvgNaturalSize constant is present and matches the SVG viewBox.
+   * Expected: dimensions match the griddle.svg viewBox="0 0 1437.2 758.8" exactly,
+   * ensuring the coordinate-space denominator is stable across Electron versions.
+   *
+   * Background: DOM naturalWidth for SVGs without explicit size attributes changed
+   * between Chromium ≤ 66 (returned 300) and Chromium 84+ (returns viewBox width).
+   * Hard-coding the viewBox value prevents a ~4.8× coordinate-space regression.
+   */
+  test('griddleSvgNaturalSize matches the griddle SVG viewBox dimensions', () => {
+    const constants = mainConfig.getAppConstants();
+
+    expect(constants).toHaveProperty('griddleSvgNaturalSize');
+    expect(constants.griddleSvgNaturalSize.width).toBe(1437.2);
+    expect(constants.griddleSvgNaturalSize.height).toBe(758.8);
+  });
+
+  /**
+   * Verifies the migration factor between legacy and current coordinate spaces.
+   * Expected: migrationFactor ≈ 4.79 (1437.2 / 300).
+   *
+   * A .pbp file saved by legacy PancakePainter (Chromium ≤ 66, naturalWidth = 300)
+   * contains path coordinates in a space ~4.79× smaller than the current space.
+   * loadPBP() applies this factor to restore paths to their intended positions.
+   */
+  test('legacy-to-current coordinate migration factor is consistent', () => {
+    const constants = mainConfig.getAppConstants();
+    const LEGACY_DENOMINATOR = 300;
+    const currentDenominator = constants.griddleSvgNaturalSize.width;
+
+    const migrationFactor = currentDenominator / LEGACY_DENOMINATOR;
+
+    // Factor must be well above 1 (legacy space is much smaller than current).
+    expect(migrationFactor).toBeGreaterThan(4);
+    expect(migrationFactor).toBeLessThan(6);
+    // Verify the exact ratio to catch any accidental constant change.
+    expect(migrationFactor).toBeCloseTo(1437.2 / 300, 3);
+  });
+
+  /**
+   * Verifies the printable-area coordinate width in the current coordinate space.
+   * Expected: ≈ 1255 project units for the 443 mm printable area.
+   *
+   * This value is used as the threshold to differentiate legacy files (< 350 units)
+   * from current files during heuristic-based migration in loadPBP().
+   */
+  test('current coordinate space gives ≈1255 project units for printable area', () => {
+    const constants = mainConfig.getAppConstants();
+
+    const projectUnitsWide =
+      constants.printableArea.width *
+      (constants.griddleSvgNaturalSize.width / constants.griddleSize.width);
+
+    // Must be well above the legacy-detection threshold of 350 units.
+    expect(projectUnitsWide).toBeGreaterThan(1000);
+    // And within a plausible range around the expected 1255 units.
+    expect(projectUnitsWide).toBeLessThan(1500);
+  });
 });


### PR DESCRIPTION
## Summary\n- stabilize editor scale denominator across Electron/Chromium versions\n- add metadata + migration for legacy/current .pbp coordinate spaces\n- fix save regression by guarding project.data before export metadata write\n- harden save/open toast fallbacks and add regression coverage\n\n## Validation\n- npm test (lint + jest)\n\nCloses #45