### PR TITLE
47: Fix export reset confirmation and default restore

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -207,3 +207,8 @@ The ndarray grid is allocated with shape [w, h] (indices 0 to w-1, 0 to h-1). Bo
 - Grid: ndarray(..., [w, h])
 - Check: if (x >= w || y >= h) return; (not x > w)
 
+**Settings reset confirmation should reuse one native dialog path and include fallback text**
+Duplicating reset confirmation logic across windows caused behavior drift (missing prompt, inconsistent button handling, and empty dialog text in some runtimes).
+- Rule: Route export reset through `mainWindow.resetSettings()` and keep one native `MessageBox` flow.
+- Rule: For all reset dialog strings (`message`, `detail`, button labels), provide fallback English text when `i18n.t(...)` returns empty or unresolved keys.
+

--- a/src/app.js
+++ b/src/app.js
@@ -1018,17 +1018,39 @@ function bindControls() {
 
   // Add settings reset helper function.
   mainWindow.resetSettings = function() {
+    var resetTitle = i18n.t('settings.resetconfirm');
+    var resetDetail = i18n.t('settings.resetconfirmdetail');
+    var cancelLabel = i18n.t('common.button.cancel');
+    var resetLabel = i18n.t('settings.button.reset');
+
+    if (!resetTitle || resetTitle === 'settings.resetconfirm') {
+      resetTitle = 'Reset to factory default settings?';
+    }
+    if (!resetDetail || resetDetail === 'settings.resetconfirmdetail') {
+      resetDetail =
+        'This will revert all settings on this page to default. ' +
+        'This cannot be undone.';
+    }
+    if (!cancelLabel || cancelLabel === 'common.button.cancel') {
+      cancelLabel = 'Cancel';
+    }
+    if (!resetLabel || resetLabel === 'settings.button.reset') {
+      resetLabel = 'Revert All Settings';
+    }
+
     var doReset = mainWindow.dialog({
       t: 'MessageBox',
       type: 'question',
-      message: i18n.t('settings.resetconfirm'),
-      detail: i18n.t('settings.resetconfirmdetail'),
+      message: resetTitle,
+      detail: resetDetail,
+      defaultId: 0,
+      cancelId: 1,
       buttons: [
-        i18n.t('common.button.cancel'),
-        i18n.t('settings.button.reset')
+        resetLabel,
+        cancelLabel
       ]
     });
-    if (doReset !== 0) {
+    if (doReset === 0) {
       // Clear the file, reload settings, push to elements.
       app.settings.reset();
       $('.settings-managed').each(function() {
@@ -1044,7 +1066,10 @@ function bindControls() {
         .rangeslider('update', true);
 
       $(window).triggerHandler('settingsChanged');
+      return true;
     }
+
+    return false;
   };
 }
 

--- a/src/helpers/helper.settings-store.js
+++ b/src/helpers/helper.settings-store.js
@@ -19,6 +19,9 @@ function createSettingsStore(options) {
     clear: function() {
       fs.removeSync(settingsFile);
     },
+    clearUserOverrides: function() {
+      fs.removeSync(userSettingsFile);
+    },
     save: function() {
       var serialized = JSON.stringify(this.v);
       try {
@@ -57,6 +60,7 @@ function createSettingsStore(options) {
     },
     reset: function() {
       this.clear();
+      this.clearUserOverrides();
       this.load();
     }
   };

--- a/src/windows/window.export.js
+++ b/src/windows/window.export.js
@@ -56,14 +56,18 @@ module.exports = function(context) {
    * Bind the various buttons on the window.
    */
   function bindButtons() {
-    $('button', context).click(function() {
+    $('button', context)
+      .off('click.exportButtons')
+      .on('click.exportButtons', function(e) {
+      e.preventDefault();
+
       switch(this.name) {
         case 'cancel':
           mainWindow.overlay.toggleWindow('export', false);
           break;
 
         case 'reset':
-          mainWindow.resetSettings();
+          exportData.resetSettings();
           break;
 
         case 'reselect':
@@ -79,7 +83,7 @@ module.exports = function(context) {
           exportData.saveData();
           break;
       }
-    });
+      });
 
     // Bind ESC key exit.
     // TODO: Build this off data attr global bind thing.
@@ -200,6 +204,28 @@ module.exports = function(context) {
     ];
 
     exportData.renderUpdate();
+  };
+
+  /**
+   * Reset export settings to defaults and refresh export controls.
+   */
+  exportData.resetSettings = function() {
+    var didReset = false;
+
+    if (typeof mainWindow.resetSettings === 'function') {
+      didReset = mainWindow.resetSettings();
+    }
+
+    if (!didReset) {
+      return;
+    }
+
+    // Mirror is export-only state and is not persisted in app settings.
+    $('#mirrorexport', context).prop('checked', function() {
+      return this.defaultChecked;
+    });
+
+    exportData.setRenderSettings();
   };
 
   /**

--- a/tests/unit/helpers/settings.store.test.js
+++ b/tests/unit/helpers/settings.store.test.js
@@ -122,6 +122,22 @@ describe('helper.settings-store', () => {
     store.reset();
 
     expect(fsMock.removeSync).toHaveBeenCalledWith('/app/settings.json');
+    expect(fsMock.removeSync).toHaveBeenCalledWith('/user/config.json');
+    expect(store.v.botspeed).toBe(70);
+  });
+
+  /**
+   * Verifies reset clears user override file as well.
+   * Expected: user config values do not survive reset and defaults are restored.
+   */
+  test('reset removes user overrides before reloading defaults', () => {
+    fileMap['/app/settings.json'] = JSON.stringify({ botspeed: 10 });
+    fileMap['/user/config.json'] = JSON.stringify({ botspeed: 95 });
+
+    store.reset();
+
+    expect(fsMock.removeSync).toHaveBeenCalledWith('/app/settings.json');
+    expect(fsMock.removeSync).toHaveBeenCalledWith('/user/config.json');
     expect(store.v.botspeed).toBe(70);
   });
 });

--- a/tests/unit/windows/window.export.reset.test.js
+++ b/tests/unit/windows/window.export.reset.test.js
@@ -1,0 +1,237 @@
+/**
+ * @file Unit tests for export window reset behavior.
+ *
+ * Scope: verifies that the Export for Printing reset action restores
+ * persisted defaults and export-only UI defaults in the export overlay.
+ */
+'use strict';
+
+const createExportWindow = require('../../../src/windows/window.export');
+
+function createElementWrapper(element) {
+  return {
+    val: function(value) {
+      if (typeof value === 'undefined') {
+        return element.value;
+      }
+      element.value = value;
+      return this;
+    },
+    prop: function(name, value) {
+      if (typeof value === 'undefined') {
+        return element[name];
+      }
+      if (typeof value === 'function') {
+        element[name] = value.call(element);
+      } else {
+        element[name] = value;
+      }
+      return this;
+    }
+  };
+}
+
+function createCollection(elements, state) {
+  return {
+    each: function(handler) {
+      elements.forEach(function(element) {
+        handler.call(element);
+      });
+      return this;
+    },
+    trigger: function(name) {
+      state.rangeTriggers.push(name);
+      return this;
+    },
+    rangeslider: function(action, forceUpdate) {
+      state.rangeUpdates.push({ action: action, forceUpdate: forceUpdate });
+      return this;
+    },
+    click: function() {
+      return this;
+    },
+    keydown: function() {
+      return this;
+    },
+    change: function() {
+      return this;
+    },
+    css: function() {
+      return this;
+    }
+  };
+}
+
+describe('window.export reset settings', function() {
+  var originalGlobals;
+
+  beforeEach(function() {
+    originalGlobals = {
+      window: global.window,
+      mainWindow: global.mainWindow,
+      app: global.app,
+      $: global.$,
+      paper: global.paper,
+      i18n: global.i18n,
+      fs: global.fs,
+      toastr: global.toastr,
+      path: global.path
+    };
+  });
+
+  afterEach(function() {
+    global.window = originalGlobals.window;
+    global.mainWindow = originalGlobals.mainWindow;
+    global.app = originalGlobals.app;
+    global.$ = originalGlobals.$;
+    global.paper = originalGlobals.paper;
+    global.i18n = originalGlobals.i18n;
+    global.fs = originalGlobals.fs;
+    global.toastr = originalGlobals.toastr;
+    global.path = originalGlobals.path;
+  });
+
+  /**
+   * Verifies confirmed reset restores persisted defaults and export-only mirror.
+   * Expected: managed controls are rewritten from defaults and mirror returns to
+   * its HTML defaultChecked state.
+   */
+  test('applies defaults in export context when reset is confirmed', function() {
+    var mirror = { id: 'mirrorexport', type: 'checkbox', checked: false, defaultChecked: true };
+    var state = {
+      rangeTriggers: [],
+      rangeUpdates: [],
+      windowEvents: [],
+      delegatedResetCalls: 0
+    };
+
+    global.window = {};
+    global.mainWindow = {
+      resetSettings: function() {
+        state.delegatedResetCalls += 1;
+        return true;
+      }
+    };
+    global.app = {
+      constants: {
+        botSpeedMax: 100
+      },
+      settings: {
+        v: { flatten: 2, uselinefill: false }
+      }
+    };
+    global.paper = {
+      view: {
+        bounds: { x: 0, y: 0, width: 1, height: 1 }
+      }
+    };
+    global.i18n = { t: function(key) { return key; } };
+    global.fs = { writeFileSync: function() {} };
+    global.toastr = { success: function() {}, error: function() {} };
+    global.path = { parse: function() { return { base: 'x.gcode' }; } };
+
+    global.$ = function(selector) {
+      if (selector === global.window) {
+        return {
+          triggerHandler: function(name) {
+            state.windowEvents.push(name);
+          },
+          on: function() {}
+        };
+      }
+
+      if (selector === '#mirrorexport') {
+        return createElementWrapper(mirror);
+      }
+
+      if (selector === '.loader') {
+        return createCollection([], state);
+      }
+
+      if (typeof selector === 'object') {
+        return createElementWrapper(selector);
+      }
+
+      return createCollection([], state);
+    };
+
+    var exportWindow = createExportWindow({});
+    exportWindow.resetSettings();
+
+    expect(state.delegatedResetCalls).toBe(1);
+    expect(mirror.checked).toBe(true);
+  });
+
+  /**
+   * Verifies cancel path does not mutate settings or controls.
+   * Expected: no settings reset and no UI updates are triggered.
+   */
+  test('does nothing when reset confirmation is cancelled', function() {
+    var mirror = { id: 'mirrorexport', type: 'checkbox', checked: false, defaultChecked: true };
+    var state = {
+      rangeTriggers: [],
+      rangeUpdates: [],
+      windowEvents: [],
+      delegatedResetCalls: 0
+    };
+
+    global.window = {};
+    global.mainWindow = {
+      resetSettings: function() {
+        state.delegatedResetCalls += 1;
+        return false;
+      }
+    };
+    global.app = {
+      constants: {
+        botSpeedMax: 100
+      },
+      settings: {
+        v: { flatten: 15, uselinefill: true }
+      }
+    };
+    global.paper = {
+      view: {
+        bounds: { x: 0, y: 0, width: 1, height: 1 }
+      }
+    };
+    global.i18n = { t: function(key) { return key; } };
+    global.fs = { writeFileSync: function() {} };
+    global.toastr = { success: function() {}, error: function() {} };
+    global.path = { parse: function() { return { base: 'x.gcode' }; } };
+
+    global.$ = function(selector) {
+      if (selector === global.window) {
+        return {
+          triggerHandler: function(name) {
+            state.windowEvents.push(name);
+          },
+          on: function() {}
+        };
+      }
+
+      if (selector === '#mirrorexport') {
+        return createElementWrapper(mirror);
+      }
+
+      if (selector === '.loader') {
+        return createCollection([], state);
+      }
+
+      if (typeof selector === 'object') {
+        return createElementWrapper(selector);
+      }
+
+      return createCollection([], state);
+    };
+
+    var exportWindow = createExportWindow({});
+    exportWindow.resetSettings();
+
+    expect(state.delegatedResetCalls).toBe(1);
+    expect(mirror.checked).toBe(false);
+    expect(state.rangeTriggers).toEqual([]);
+    expect(state.rangeUpdates).toEqual([]);
+    expect(state.windowEvents).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary\n- fix Export for Printing reset flow to restore default settings and sync UI control values\n- add/reset wiring coverage for export window reset behavior\n- add/update unit coverage for settings store default restore paths\n\nFixes #47