### PR TITLE
42: Show Save/Discard/Cancel confirmation when closing with unsaved changes

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -212,3 +212,16 @@ Duplicating reset confirmation logic across windows caused behavior drift (missi
 - Rule: Route export reset through `mainWindow.resetSettings()` and keep one native `MessageBox` flow.
 - Rule: For all reset dialog strings (`message`, `detail`, button labels), provide fallback English text when `i18n.t(...)` returns empty or unresolved keys.
 
+**`checkFileStatus` callback must only be invoked for async Save-As, not all sync paths**
+When `checkFileStatus` was called unconditionally at the end for sync paths (DISCARD, existing save), passing `window.close` as the callback caused re-entrant `window.onbeforeunload` execution.
+- Rule: `checkFileStatus` should return `true` for synchronous success without calling any callback. Callers must handle `true` return directly and pass a callback only for the async Save-As path.
+- Implementation: Renamed param `callback` → `onAsyncComplete`; removed `if (callback) callback()` at function bottom; updated `file.open` and `file.new/close` switcher cases to call their action function directly when `checkFileStatus` returns `true`.
+
+**JSHint `unused: strict` flags all unused function parameters, including leading ones before used params**
+Parameter names that become unused after simplification (e.g., after removing a dead branch that referenced them) will produce lint errors.
+- Rule: Either use the parameter or remove it from the signature. In JavaScript, callers can still pass extra args safely. Update all call sites and tests accordingly.
+
+**JSHint `unused: strict` + `expr: false` means no `void expr;` to silence unused-param warnings**
+The `expr: false` option forbids expression statements, so `void param;` is rejected as a suppressor.
+- Rule: Remove unused parameters from the signature; update callers. Do not rely on `void` or standalone expression statements to suppress lint warnings.
+

--- a/src/app.js
+++ b/src/app.js
@@ -895,7 +895,9 @@ function bindControls() {
         break;
       case 'file.open':
         if (!document.hasFocus()) return; // Triggered from devtools otherwise
-        checkFileStatus(function() {
+        // Shared action: invoked as onAsyncComplete callback (after Save-As)
+        // and directly when checkFileStatus returns true (synchronous paths).
+        var doOpenFileDialog = function() {
           mainWindow.dialog({
             t: 'OpenDialog',
             title: i18n.t(menu),
@@ -913,14 +915,22 @@ function bindControls() {
               filePath: filePath[0]
             });
           });
-        });
+        };
+        if (checkFileStatus(doOpenFileDialog)) {
+          doOpenFileDialog();
+        }
         break;
       case 'file.new':
       case 'file.close':
-        checkFileStatus(function(){
+        // Shared action: invoked as onAsyncComplete callback (after Save-As)
+        // and directly when checkFileStatus returns true (synchronous paths).
+        var doNewFile = function() {
           toastr.info(i18n.t(menu));
           paper.newPBP();
-        });
+        };
+        if (checkFileStatus(doNewFile)) {
+          doNewFile();
+        }
         break;
       case 'edit.selectall':
         paper.selectAll();
@@ -1238,14 +1248,20 @@ mainWindow.overlay = {
 
 // Check the current file status and return whether
 // the current action may proceed.
-function checkFileStatus(callback) {
+//
+// @param {Function|null} onAsyncComplete - invoked ONLY when an async Save-As
+//   is initiated and completes. For synchronous paths (DISCARD, existing-file
+//   Save), this function returns `true` and callers must proceed directly.
+//   Keeping the callback exclusive to the async path prevents re-entrant
+//   window-close calls when called from window.onbeforeunload.
+function checkFileStatus(onAsyncComplete) {
   if (app.currentFile.changed) {
     var promptModel = unsavedChanges.buildClosePromptModel({
       i18n: i18n,
       currentFile: app.currentFile
     });
     var selection = mainWindow.dialog(promptModel.dialogOptions);
-    var action = unsavedChanges.resolveCloseAction(app.currentFile, selection);
+    var action = unsavedChanges.resolveCloseAction(selection);
 
     if (action === unsavedChanges.actions.CANCEL) {
       return false;
@@ -1254,19 +1270,23 @@ function checkFileStatus(callback) {
     if (action === unsavedChanges.actions.SAVE) {
       if (app.currentFile.name === "") {
         // Save-as is async and must complete before continuing.
+        // onAsyncComplete is called only when this async path finishes.
         app.menuClick('file.save', function(){
-          if (callback) callback();
+          if (onAsyncComplete) onAsyncComplete();
         });
         return false;
       }
 
-      app.menuClick('file.save');
+      // Only allow the pending action to continue when the save succeeds.
+      var saveSucceeded = app.menuClick('file.save');
+      if (saveSucceeded !== true) {
+        return false;
+      }
     } else {
       toastr.warning(i18n.t('file.discarded'));
     }
   }
 
-  if (callback) callback();
   return true;
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -52,6 +52,7 @@ var app = {
 };
 var fs = bridge.fs;
 var rendererModuleCache = {};
+var unsavedChanges = loadRendererModule('./helpers/helper.unsaved-changes.js');
 
 function getRendererFs() {
   return {
@@ -1073,16 +1074,24 @@ function bindControls() {
   };
 }
 
-// Handle unsaved file changes before window close
-window.onbeforeunload = function() {
-  // Only prevent close if changes AND dialog not processed
-  if (app.currentFile.changed) {
-    // checkFileStatus handles dialog, returns false if async save started
-    checkFileStatus();
-    // Don't return - let Electron handle close
-    // If unsaved changes, checkFileStatus already showed dialog
+// Handle unsaved file changes before window close.
+window.onbeforeunload = function(e) {
+  if (!app.currentFile.changed) {
+    return;
   }
-  // Always allow close (return undefined)
+
+  var shouldClose = checkFileStatus(function() {
+    // Save-as is async. Re-trigger close when that save successfully completes.
+    window.close();
+  });
+
+  if (shouldClose === false) {
+    if (e) {
+      e.returnValue = false;
+    }
+    return false;
+  }
+
   return;
 };
 
@@ -1227,62 +1236,38 @@ mainWindow.overlay = {
   currentWindow: {}
 };
 
-// Check the current file status and alert the user what to do before continuing
-// This is pretty forceful and there's no way to back out.
+// Check the current file status and return whether
+// the current action may proceed.
 function checkFileStatus(callback) {
   if (app.currentFile.changed) {
-    var doSave = 0;
-    if (app.currentFile.name === "") { // New file or existing?
-      // Save new is async and needs to cancel the close and use a callback
-      doSave = mainWindow.dialog({
-        t: 'MessageBox',
-        type: 'warning',
-        message: i18n.t('file.confirm.notsaved'),
-        detail: i18n.t('file.confirm.savenew'),
-        buttons:[i18n.t('file.button.discard'), i18n.t('file.button.savenew')]
-      });
+    var promptModel = unsavedChanges.buildClosePromptModel({
+      i18n: i18n,
+      currentFile: app.currentFile
+    });
+    var selection = mainWindow.dialog(promptModel.dialogOptions);
+    var action = unsavedChanges.resolveCloseAction(app.currentFile, selection);
 
-      if (doSave) {
+    if (action === unsavedChanges.actions.CANCEL) {
+      return false;
+    }
+
+    if (action === unsavedChanges.actions.SAVE) {
+      if (app.currentFile.name === "") {
+        // Save-as is async and must complete before continuing.
         app.menuClick('file.save', function(){
           if (callback) callback();
         });
         return false;
-      } else {
-        toastr.warning(i18n.t('file.discarded'));
       }
 
+      app.menuClick('file.save');
     } else {
-      doSave = mainWindow.dialog({
-        t: 'MessageBox',
-        type: 'warning',
-        message: i18n.t('file.confirm.changed'),
-        detail: i18n.t('file.confirm.save', {file: app.currentFile.name}),
-        buttons:[
-          i18n.t('file.button.discard'),
-          i18n.t('file.button.save'),
-          i18n.t('file.button.savenew')
-        ]
-      });
-
-      if (doSave) {
-        if (doSave === 1) { // Save current file
-          // Save in place is sync, so doesn't need to cancel close
-          app.menuClick('file.save');
-        } else { // Save new file
-          app.menuClick('file.saveas', function(){
-            if (callback) callback();
-          });
-          return false;
-        }
-      } else {
-        toastr.warning(i18n.t('file.discarded'));
-      }
+      toastr.warning(i18n.t('file.discarded'));
     }
   }
 
   if (callback) callback();
-  // Don't return true - allow close to proceed
-  return;
+  return true;
 }
 
 

--- a/src/helpers/helper.unsaved-changes.js
+++ b/src/helpers/helper.unsaved-changes.js
@@ -22,7 +22,7 @@ function translateWithFallback(i18n, key, fallback, vars) {
 function buildClosePromptModel(options) {
   var i18n = options.i18n;
   var currentFile = options.currentFile || {};
-  var isNewFile = currentFile.name === '';
+  var isNewFile = !currentFile.name;
   var buttons;
   var message;
   var detail;
@@ -75,18 +75,12 @@ function buildClosePromptModel(options) {
   };
 }
 
-function resolveCloseAction(currentFile, selectedIndex) {
-  var isNewFile = !currentFile || currentFile.name === '';
-
+function resolveCloseAction(selectedIndex) {
   if (selectedIndex === 0) {
     return actions.DISCARD;
   }
 
   if (selectedIndex === 1) {
-    if (isNewFile) {
-      return actions.SAVE;
-    }
-
     return actions.SAVE;
   }
 

--- a/src/helpers/helper.unsaved-changes.js
+++ b/src/helpers/helper.unsaved-changes.js
@@ -1,0 +1,100 @@
+/**
+ * @file Helpers for unsaved-changes close prompts in the renderer.
+ */
+'use strict';
+
+var actions = {
+  DISCARD: 'discard',
+  SAVE: 'save',
+  CANCEL: 'cancel'
+};
+
+function translateWithFallback(i18n, key, fallback, vars) {
+  var translated = i18n.t(key, vars || {});
+
+  if (translated && translated !== key) {
+    return translated;
+  }
+
+  return fallback;
+}
+
+function buildClosePromptModel(options) {
+  var i18n = options.i18n;
+  var currentFile = options.currentFile || {};
+  var isNewFile = currentFile.name === '';
+  var buttons;
+  var message;
+  var detail;
+
+  if (isNewFile) {
+    message = translateWithFallback(
+      i18n,
+      'file.confirm.notsaved',
+      'Project file has not been saved!'
+    );
+    detail = translateWithFallback(
+      i18n,
+      'file.confirm.savenew',
+      'Save new project before continuing?'
+    );
+    buttons = [
+      translateWithFallback(i18n, 'file.button.discard', 'Discard changes'),
+      translateWithFallback(i18n, 'file.button.savenew', 'Save as a new file'),
+      translateWithFallback(i18n, 'common.button.cancel', 'Cancel')
+    ];
+  } else {
+    message = translateWithFallback(
+      i18n,
+      'file.confirm.changed',
+      'Project has changed since last save!'
+    );
+    detail = translateWithFallback(
+      i18n,
+      'file.confirm.save',
+      'Save changes before continuing?',
+      { file: currentFile.name }
+    );
+    buttons = [
+      translateWithFallback(i18n, 'file.button.discard', 'Discard changes'),
+      translateWithFallback(i18n, 'file.button.save', 'Save current file'),
+      translateWithFallback(i18n, 'common.button.cancel', 'Cancel')
+    ];
+  }
+
+  return {
+    dialogOptions: {
+      t: 'MessageBox',
+      type: 'warning',
+      message: message,
+      detail: detail,
+      defaultId: 1,
+      cancelId: 2,
+      buttons: buttons
+    }
+  };
+}
+
+function resolveCloseAction(currentFile, selectedIndex) {
+  var isNewFile = !currentFile || currentFile.name === '';
+
+  if (selectedIndex === 0) {
+    return actions.DISCARD;
+  }
+
+  if (selectedIndex === 1) {
+    if (isNewFile) {
+      return actions.SAVE;
+    }
+
+    return actions.SAVE;
+  }
+
+  return actions.CANCEL;
+}
+
+module.exports = {
+  actions: actions,
+  buildClosePromptModel: buildClosePromptModel,
+  resolveCloseAction: resolveCloseAction
+};

--- a/tests/unit/helpers/unsaved.changes.test.js
+++ b/tests/unit/helpers/unsaved.changes.test.js
@@ -75,13 +75,13 @@ describe('helper.unsaved-changes', () => {
    * Expected: 0=discard, 1=save, any other index=cancel.
    */
   test('resolveCloseAction maps selections to discard/save/cancel', () => {
-    expect(unsavedChanges.resolveCloseAction({ name: '' }, 0)).toBe(
+    expect(unsavedChanges.resolveCloseAction(0)).toBe(
       unsavedChanges.actions.DISCARD
     );
-    expect(unsavedChanges.resolveCloseAction({ name: 'a.pbp' }, 1)).toBe(
+    expect(unsavedChanges.resolveCloseAction(1)).toBe(
       unsavedChanges.actions.SAVE
     );
-    expect(unsavedChanges.resolveCloseAction({ name: 'a.pbp' }, 2)).toBe(
+    expect(unsavedChanges.resolveCloseAction(2)).toBe(
       unsavedChanges.actions.CANCEL
     );
   });

--- a/tests/unit/helpers/unsaved.changes.test.js
+++ b/tests/unit/helpers/unsaved.changes.test.js
@@ -1,0 +1,104 @@
+/**
+ * @file Unit tests for helper.unsaved-changes.js
+ *
+ * Scope: verify Save/Discard/Cancel close prompt modeling and action mapping
+ * for new and existing project files.
+ */
+'use strict';
+
+const unsavedChanges = require('../../../src/helpers/helper.unsaved-changes');
+
+describe('helper.unsaved-changes', () => {
+  let i18n;
+
+  beforeEach(() => {
+    i18n = {
+      t: jest.fn((key, vars) => {
+        const dictionary = {
+          'file.confirm.notsaved': 'Project file has not been saved!',
+          'file.confirm.savenew': 'Save new project before continuing?',
+          'file.confirm.changed': 'Project has changed since last save!',
+          'file.button.discard': 'Discard changes',
+          'file.button.savenew': 'Save as a new file',
+          'file.button.save': 'Save current file',
+          'common.button.cancel': 'Cancel'
+        };
+
+        if (key === 'file.confirm.save') {
+          return 'Save changes to "' + (vars && vars.file) + '" before continuing?';
+        }
+
+        return dictionary[key] || key;
+      })
+    };
+  });
+
+  /**
+   * Verifies new-file prompt semantics.
+   * Expected: Discard/Save As/Cancel with cancel index configured.
+   */
+  test('buildClosePromptModel for new file includes cancel option', () => {
+    const model = unsavedChanges.buildClosePromptModel({
+      i18n: i18n,
+      currentFile: { name: '' }
+    });
+
+    expect(model.dialogOptions.buttons).toEqual([
+      'Discard changes',
+      'Save as a new file',
+      'Cancel'
+    ]);
+    expect(model.dialogOptions.defaultId).toBe(1);
+    expect(model.dialogOptions.cancelId).toBe(2);
+  });
+
+  /**
+   * Verifies existing-file prompt semantics.
+   * Expected: Discard/Save/Cancel and detail references file name.
+   */
+  test('buildClosePromptModel for existing file includes save and cancel', () => {
+    const model = unsavedChanges.buildClosePromptModel({
+      i18n: i18n,
+      currentFile: { name: 'design.pbp' }
+    });
+
+    expect(model.dialogOptions.buttons).toEqual([
+      'Discard changes',
+      'Save current file',
+      'Cancel'
+    ]);
+    expect(model.dialogOptions.detail).toContain('design.pbp');
+  });
+
+  /**
+   * Verifies action mapping for all button indexes.
+   * Expected: 0=discard, 1=save, any other index=cancel.
+   */
+  test('resolveCloseAction maps selections to discard/save/cancel', () => {
+    expect(unsavedChanges.resolveCloseAction({ name: '' }, 0)).toBe(
+      unsavedChanges.actions.DISCARD
+    );
+    expect(unsavedChanges.resolveCloseAction({ name: 'a.pbp' }, 1)).toBe(
+      unsavedChanges.actions.SAVE
+    );
+    expect(unsavedChanges.resolveCloseAction({ name: 'a.pbp' }, 2)).toBe(
+      unsavedChanges.actions.CANCEL
+    );
+  });
+
+  /**
+   * Verifies fallback rendering when translations are unavailable.
+   * Expected: fallback text is used and action labels stay non-empty.
+   */
+  test('buildClosePromptModel falls back when i18n returns unresolved keys', () => {
+    i18n.t.mockImplementation((key) => key);
+
+    const model = unsavedChanges.buildClosePromptModel({
+      i18n: i18n,
+      currentFile: { name: '' }
+    });
+
+    expect(model.dialogOptions.message).toBe('Project file has not been saved!');
+    expect(model.dialogOptions.buttons[2]).toBe('Cancel');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #42

Implements a consistent Save / Discard / Cancel confirmation dialog for all paths where the user may lose unsaved work:
- Clicking the window X button.
- Using File > Close or File > New from the menu.

## Changes

### src/helpers/helper.unsaved-changes.js (new)
Pure helper module that:
- Builds the dialog prompt model for new and existing project files (with i18n + English fallbacks).
- Maps the user's button selection (0 = Discard, 1 = Save, 2 = Cancel) to an action constant.

### src/app.js
- \checkFileStatus()\ now delegates prompt construction to the helper, returns \	rue\ (proceed) or \alse\ (cancelled/async-pending), and supports Cancel without closing the window.
- \window.onbeforeunload\ blocks the close event when Cancel is chosen, and schedules a re-close after async Save As completes.

### 	ests/unit/helpers/unsaved.changes.test.js (new)
Four focused unit tests:
1. New-file prompt includes Discard / Save As / Cancel buttons with correct default and cancel indexes.
2. Existing-file prompt includes Discard / Save / Cancel buttons and detail referencing the file name.
3. Action mapping: 0 → DISCARD, 1 → SAVE, 2 → CANCEL.
4. Fallback English text used when i18n returns unresolved keys.

## Validation
- \
pm test\ passes: 11 / 11 suites, 66 / 66 tests (lint + Jest)