### PR TITLE
Issue #52: Fix export webview preload sandbox module resolution

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -246,7 +246,8 @@ script. This causes the entire preload to refuse to load, breaking the IPC bridg
 **IPC channel allowlist defined in the preload will drift from the shared registry**
 A local `channels` object in `webview-preload.js` that mirrors `ipc-channels.js` has no enforcement link.
 New channels added to `ipc-channels.js` will not be automatically allowed in the preload.
-- Rule: In `webview-preload.js`, always `require('../ipc-channels.js')` rather than duplicating the object literal. This makes the preload allowlist a strict subset of the shared registry by construction.
+- Rule: In `webview-preload.js`, attempt `require('../ipc-channels.js')` first and keep the preload allowlist sourced from the shared registry in normal contexts.
+- Rule: Only duplicate the object literal inside a guarded fallback for module-resolution failures in sandbox/webview contexts; rethrow unexpected require errors.
 
 **Polling scripts should be parameterized, not duplicated per PR**
 Creating a new `.ps1` file for each PR number results in identical scripts that must all be updated when the detection logic changes.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -229,10 +229,19 @@ The `expr: false` option forbids expression statements, so `void param;` is reje
 The staged renderer loader resolves package paths manually and failed on dependencies that expect native Node core modules (for example, `util`), causing startup ENOENT errors like `node_modules/util/index.js`.
 - Rule: In renderer flows that run through a custom module resolver, avoid introducing heavy packages with deep Node dependency trees unless built-ins are explicitly handled by the resolver. Prefer existing renderer-safe helpers (for example, Paper.js raster/export utilities) for image pipeline tasks.
 
-**Webview preload `joinPath` must delegate to Node's `path` module, not hardcode backslashes**
-Implementing `joinPath` with `Array.join('\\')` produces correct results on Windows only.
-On macOS/Linux, module resolution paths passed through `resolveAppModule` fail because paths contain backslashes that are not treated as separators.
-- Rule: In preload scripts, `require('path')` is available (preloads run with Node access). Use `nodePath.join.apply(nodePath, args)` and `nodePath.parse(filePath)` instead of manual string joining, so the shim is cross-platform by construction.
+**Webview preload top-level `require()` fails in the simulator/webview sandbox**
+The Electron webview/simulator sandbox cannot resolve either Node built-ins (`path`) or
+relative module paths (`../ipc-channels.js`) via `require()` at the top level of a preload
+script. This causes the entire preload to refuse to load, breaking the IPC bridge.
+- Rule: Any `require()` at the top level of a webview preload that could run in a sandbox
+  must be wrapped in a `try/catch`. For Node built-ins (`path`), set the result to `null`
+  and activate a pure-JS fallback. For relative requires (channel registries), provide an
+  inline copy of the same definitions as the catch fallback to keep channels in sync with
+  the authoritative source without duplicating them in a non-guarded way.
+- Rule: Use `nodePath.join.apply(nodePath, args)` when `nodePath` is available; otherwise
+  use a pure-JS fallback that detects the separator from the first argument.
+- Implementation: `src/preload/webview-preload.js` — try/catch on both `require('path')`
+  and `require('../ipc-channels.js')` with matching fallbacks.
 
 **IPC channel allowlist defined in the preload will drift from the shared registry**
 A local `channels` object in `webview-preload.js` that mirrors `ipc-channels.js` has no enforcement link.

--- a/src/preload/webview-preload.js
+++ b/src/preload/webview-preload.js
@@ -5,21 +5,57 @@
 "use strict";
 
 var electron = require('electron');
-var nodePath = require('path');
+// `path` is a Node built-in. In the Electron webview/simulator sandbox it
+// cannot be resolved; the try/catch keeps the module loading and signals
+// the pure-JS joinPath/parse fallbacks to activate.
+var nodePath = null;
+try {
+  nodePath = require('path');
+} catch (e) {
+  nodePath = null;
+}
 var contextBridge = electron.contextBridge;
 var ipcRenderer = electron.ipcRenderer;
 var bootstrap = ipcRenderer.sendSync('app:get-bootstrap') || {};
 
-// Use the shared IPC channel registry to avoid drift between preload and main.
-var channels = require('../ipc-channels.js');
+// Use the shared IPC channel registry. In the webview/simulator sandbox,
+// relative requires fail; the try/catch activates an inline copy of the
+// same definitions to avoid drift.
+var channels = null;
+try {
+  channels = require('../ipc-channels.js');
+} catch (e) {
+  channels = {
+    autotrace: {
+      IN: ['loadTraceImage', 'renderTrigger', 'pickColor', 'cleanup'],
+      OUT: [
+        'paperReady', 'initLoaded', 'renderComplete',
+        'clonePreview', 'progress', 'colorPicked'
+      ]
+    },
+    export: {
+      IN: ['loadInit', 'renderTrigger', 'cleanup'],
+      OUT: ['paperReady', 'initLoaded', 'renderComplete']
+    }
+  };
+}
 var appRoot = bootstrap.appPath || '';
 
 /**
  * Joins path segments using the OS-native separator so the shim works
  * correctly on both Windows (back-slash) and macOS/Linux (forward-slash).
+ * Falls back to a pure-JS implementation when `path` is unavailable (webview
+ * sandbox / simulator context).
  */
 function joinPath() {
-  return nodePath.join.apply(nodePath, Array.prototype.slice.call(arguments));
+  var args = Array.prototype.slice.call(arguments);
+  if (nodePath) {
+    return nodePath.join.apply(nodePath, args);
+  }
+  // Pure-JS fallback: preserve Windows or POSIX separator derived from the
+  // first segment, then collapse any doubled separators produced by the join.
+  var sep = (args[0] && args[0].indexOf('\\') !== -1) ? '\\' : '/';
+  return args.join(sep).replace(sep === '\\' ? /[/\\]{2,}/g : /\/+/g, sep);
 }
 
 function getPathShim() {
@@ -36,8 +72,21 @@ function getPathShim() {
       return dotIndex > -1 ? baseName.slice(dotIndex) : '';
     },
     parse: function(filePath) {
-      // Delegate to Node's path.parse for correct cross-platform results.
-      return nodePath.parse(filePath || '');
+      // Delegate to Node's path.parse when available for correct results.
+      if (nodePath) {
+        return nodePath.parse(filePath || '');
+      }
+      // Pure-JS fallback used in the webview/simulator sandbox.
+      var f = filePath || '';
+      var lastSep = Math.max(f.lastIndexOf('/'), f.lastIndexOf('\\'));
+      var base = lastSep > -1 ? f.slice(lastSep + 1) : f;
+      var dir  = lastSep > -1 ? f.slice(0, lastSep) : '';
+      var dotIndex = base.lastIndexOf('.');
+      var ext  = dotIndex > 0 ? base.slice(dotIndex) : '';
+      var name = dotIndex > 0 ? base.slice(0, dotIndex) : base;
+      var root = /^[a-zA-Z]:[\\/]/.test(f) ? f.slice(0, 3) :
+                 /^[\\/]/.test(f) ? f.slice(0, 1) : '';
+      return { root: root, dir: dir, base: base, ext: ext, name: name };
     }
   };
 }

--- a/src/preload/webview-preload.js
+++ b/src/preload/webview-preload.js
@@ -5,6 +5,21 @@
 "use strict";
 
 var electron = require('electron');
+function isModuleResolutionError(err, moduleName) {
+  var msg = err && err.message ? String(err.message) : '';
+  return Boolean(
+    err && (
+      err.code === 'MODULE_NOT_FOUND' ||
+      msg.indexOf("Cannot find module '") !== -1 ||
+      msg.toLowerCase().indexOf('module not found') !== -1
+    ) && (
+        !moduleName ||
+        msg.indexOf(moduleName) !== -1 ||
+        err.code === 'MODULE_NOT_FOUND'
+    )
+  );
+}
+
 // `path` is a Node built-in. In the Electron webview/simulator sandbox it
 // cannot be resolved; the try/catch keeps the module loading and signals
 // the pure-JS joinPath/parse fallbacks to activate.
@@ -12,7 +27,11 @@ var nodePath = null;
 try {
   nodePath = require('path');
 } catch (e) {
-  nodePath = null;
+  if (isModuleResolutionError(e, 'path')) {
+    nodePath = null;
+  } else {
+    throw e;
+  }
 }
 var contextBridge = electron.contextBridge;
 var ipcRenderer = electron.ipcRenderer;
@@ -25,19 +44,23 @@ var channels = null;
 try {
   channels = require('../ipc-channels.js');
 } catch (e) {
-  channels = {
-    autotrace: {
-      IN: ['loadTraceImage', 'renderTrigger', 'pickColor', 'cleanup'],
-      OUT: [
-        'paperReady', 'initLoaded', 'renderComplete',
-        'clonePreview', 'progress', 'colorPicked'
-      ]
-    },
-    export: {
-      IN: ['loadInit', 'renderTrigger', 'cleanup'],
-      OUT: ['paperReady', 'initLoaded', 'renderComplete']
-    }
-  };
+  if (isModuleResolutionError(e, '../ipc-channels.js')) {
+    channels = {
+      autotrace: {
+        IN: ['loadTraceImage', 'renderTrigger', 'pickColor', 'cleanup'],
+        OUT: [
+          'paperReady', 'initLoaded', 'renderComplete',
+          'clonePreview', 'progress', 'colorPicked'
+        ]
+      },
+      export: {
+        IN: ['loadInit', 'renderTrigger', 'cleanup'],
+        OUT: ['paperReady', 'initLoaded', 'renderComplete']
+      }
+    };
+  } else {
+    throw e;
+  }
 }
 var appRoot = bootstrap.appPath || '';
 
@@ -52,10 +75,34 @@ function joinPath() {
   if (nodePath) {
     return nodePath.join.apply(nodePath, args);
   }
-  // Pure-JS fallback: preserve Windows or POSIX separator derived from the
-  // first segment, then collapse any doubled separators produced by the join.
-  var sep = (args[0] && args[0].indexOf('\\') !== -1) ? '\\' : '/';
-  return args.join(sep).replace(sep === '\\' ? /[/\\]{2,}/g : /\/+/g, sep);
+  // Pure-JS fallback: ignore empty segments (except explicit roots) and
+  // preserve UNC prefixes on Windows while collapsing duplicated separators.
+  var normalizedArgs = args.filter(function(segment) {
+    if (segment === null || typeof segment === 'undefined') {
+      return false;
+    }
+    var value = String(segment);
+    return value !== '' || /^(?:[a-zA-Z]:[\\/]|[\\/]{1,2})$/.test(value);
+  }).map(function(segment) {
+    return String(segment);
+  });
+
+  if (!normalizedArgs.length) {
+    return '.';
+  }
+
+  var sep = (normalizedArgs[0].indexOf('\\') !== -1) ? '\\' : '/';
+  var joinedPath = normalizedArgs.join(sep);
+
+  if (sep !== '\\') {
+    return joinedPath.replace(/\/+/g, sep);
+  }
+
+  var hasUncPrefix = joinedPath.indexOf('\\\\') === 0;
+  var normalizedPath = (hasUncPrefix ? joinedPath.slice(2) : joinedPath)
+    .replace(/[/\\]{2,}/g, sep);
+
+  return (hasUncPrefix ? '\\\\' : '') + normalizedPath;
 }
 
 function getPathShim() {
@@ -79,13 +126,21 @@ function getPathShim() {
       // Pure-JS fallback used in the webview/simulator sandbox.
       var f = filePath || '';
       var lastSep = Math.max(f.lastIndexOf('/'), f.lastIndexOf('\\'));
+      var hasDriveRoot = /^[a-zA-Z]:[\\/]/.test(f);
+      var root = hasDriveRoot ? f.slice(0, 3) :
+                 /^[\\/]/.test(f) ? f.slice(0, 1) : '';
       var base = lastSep > -1 ? f.slice(lastSep + 1) : f;
-      var dir  = lastSep > -1 ? f.slice(0, lastSep) : '';
+      var dir = '';
+      if (lastSep > -1) {
+        if ((lastSep === 0 && root) || (lastSep === 2 && hasDriveRoot)) {
+          dir = root;
+        } else {
+          dir = f.slice(0, lastSep);
+        }
+      }
       var dotIndex = base.lastIndexOf('.');
       var ext  = dotIndex > 0 ? base.slice(dotIndex) : '';
       var name = dotIndex > 0 ? base.slice(0, dotIndex) : base;
-      var root = /^[a-zA-Z]:[\\/]/.test(f) ? f.slice(0, 3) :
-                 /^[\\/]/.test(f) ? f.slice(0, 1) : '';
       return { root: root, dir: dir, base: base, ext: ext, name: name };
     }
   };

--- a/tests/unit/preload/webview-preload.path.test.js
+++ b/tests/unit/preload/webview-preload.path.test.js
@@ -144,6 +144,16 @@ describe('webview-preload — joinPath fallback (no path module)', function() {
     var result = win.webviewBridge.path.join('/test/', '/gcode.js');
     expect(result).not.toMatch(/\/\//);
   });
+
+  /**
+   * Verifies empty first segments do not introduce a leading separator.
+   * Expected: behaves like path.join('', 'src') -> 'src'.
+   */
+  test('matches path.join when first segment is empty', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.join('', 'src');
+    expect(result).toBe('src');
+  });
 });
 
 describe('webview-preload — parse fallback (no path module)', function() {
@@ -182,6 +192,30 @@ describe('webview-preload — parse fallback (no path module)', function() {
     var result = win.webviewBridge.path.parse('gcode.js');
     expect(result.base).toBe('gcode.js');
     expect(result.dir).toBe('');
+  });
+
+  /**
+   * Verifies root-level POSIX files preserve '/' as the directory.
+   * Expected: '/file.js' yields dir '/'.
+   */
+  test('parses root-level POSIX file with root directory', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.parse('/file.js');
+    expect(result.base).toBe('file.js');
+    expect(result.dir).toBe('/');
+    expect(result.root).toBe('/');
+  });
+
+  /**
+   * Verifies drive-root Windows files preserve 'C:\\' as the directory.
+   * Expected: 'C:\\file.js' yields dir and root 'C:\\'.
+   */
+  test('parses drive-root Windows file with drive directory', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.parse('C:\\file.js');
+    expect(result.base).toBe('file.js');
+    expect(result.dir).toBe('C:\\');
+    expect(result.root).toBe('C:\\');
   });
 });
 

--- a/tests/unit/preload/webview-preload.path.test.js
+++ b/tests/unit/preload/webview-preload.path.test.js
@@ -1,0 +1,204 @@
+/**
+ * @file Unit tests for the webview-preload.js path shim and sandbox resilience.
+ *
+ * Scope: verifies that webview-preload.js loads cleanly when the Node.js
+ * `path` built-in and relative requires (e.g. ipc-channels.js) are unavailable
+ * (as happens in the Electron webview/simulator sandbox), and that the pure-JS
+ * fallback implementations of `joinPath` and `path.parse` produce correct
+ * cross-platform results.
+ *
+ * Background:
+ * - Issue #52 — `var nodePath = require('path')` at the top level caused
+ *   "module not found: path" in the simulator context.
+ * - Follow-on — `require('../ipc-channels.js')` caused "module not found:
+ *   ../ipc-channels.js" in the same context, crashing the IPC bridge setup.
+ */
+'use strict';
+
+/**
+ * Loads webview-preload.js in a fresh module registry with controlled mocks.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.pathThrows=false]   Simulate path module unavailable.
+ * @param {boolean} [opts.channelsThrow=false] Simulate ipc-channels unavailable.
+ * @returns {object} The global.window object populated by the preload.
+ */
+function loadPreload(opts) {
+  var pathThrows    = opts && opts.pathThrows;
+  var channelsThrow = opts && opts.channelsThrow;
+
+  jest.resetModules();
+
+  if (pathThrows) {
+    jest.doMock('path', function() {
+      throw new Error('module not found: path');
+    });
+  }
+
+  if (channelsThrow) {
+    jest.doMock('../../../src/ipc-channels.js', function() {
+      throw new Error('module not found: ../ipc-channels.js');
+    });
+  }
+
+  jest.doMock('electron', function() {
+    return {
+      contextBridge: null, // Forces window.webviewBridge assignment path.
+      ipcRenderer: {
+        sendSync: jest.fn().mockReturnValue({
+          appPath: '/test/app',
+          constants: {}
+        }),
+        on: jest.fn()
+      }
+    };
+  });
+
+  global.window = {};
+  require('../../../src/preload/webview-preload');
+  return global.window;
+}
+
+afterEach(function() {
+  jest.dontMock('path');
+  jest.dontMock('../../../src/ipc-channels.js');
+  jest.dontMock('electron');
+  delete global.window;
+});
+
+describe('webview-preload — sandbox resilience', function() {
+  /**
+   * Core regression test for Issue #52 (path module).
+   * Expected: module initialises without throwing when path is unavailable.
+   */
+  test('loads without error when path module is unavailable', function() {
+    expect(function() {
+      loadPreload({ pathThrows: true });
+    }).not.toThrow();
+  });
+
+  /**
+   * Regression test for follow-on Issue #52 error (ipc-channels.js).
+   * Expected: module loads cleanly when the relative require for
+   * ipc-channels.js also fails (full webview sandbox simulation).
+   */
+  test('loads without error when ipc-channels.js is unavailable', function() {
+    expect(function() {
+      loadPreload({ pathThrows: true, channelsThrow: true });
+    }).not.toThrow();
+  });
+
+  /**
+   * Verifies the IPC bridge is functional using the inline fallback channels
+   * when ipc-channels.js cannot be resolved.
+   * Expected: webviewBridge.ipc.on and sendToHost exist and are callable.
+   */
+  test('exposes IPC bridge using inline channel fallback', function() {
+    var win = loadPreload({ pathThrows: true, channelsThrow: true });
+    expect(typeof win.webviewBridge.ipc.on).toBe('function');
+    expect(typeof win.webviewBridge.ipc.sendToHost).toBe('function');
+  });
+
+  /**
+   * Verifies the webviewBridge.path API is fully exposed after loading
+   * without the path module, so downstream consumers are not broken.
+   * Expected: join, basename, extname, and parse are callable functions.
+   */
+  test('exposes path API on webviewBridge when path module is unavailable', function() {
+    var win = loadPreload({ pathThrows: true });
+    var pathApi = win.webviewBridge.path;
+    expect(typeof pathApi.join).toBe('function');
+    expect(typeof pathApi.basename).toBe('function');
+    expect(typeof pathApi.extname).toBe('function');
+    expect(typeof pathApi.parse).toBe('function');
+  });
+});
+
+describe('webview-preload — joinPath fallback (no path module)', function() {
+  /**
+   * Verifies the pure-JS joinPath fallback joins POSIX segments correctly.
+   * Expected: segments separated by '/' when the first segment has no backslash.
+   */
+  test('joins POSIX path segments with forward-slash separator', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.join('/test/app', 'src', 'gcode.js');
+    expect(result).toBe('/test/app/src/gcode.js');
+  });
+
+  /**
+   * Verifies the pure-JS joinPath fallback handles Windows paths correctly.
+   * Expected: segments separated by backslash when the first segment uses them.
+   */
+  test('joins Windows path segments with backslash separator', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.join('C:\\Users\\app', 'src', 'file.js');
+    expect(result).toBe('C:\\Users\\app\\src\\file.js');
+  });
+
+  /**
+   * Verifies double separators produced by joining are collapsed.
+   * Expected: no doubled slashes appear in the resulting path.
+   */
+  test('collapses duplicate separators in joined POSIX path', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.join('/test/', '/gcode.js');
+    expect(result).not.toMatch(/\/\//);
+  });
+});
+
+describe('webview-preload — parse fallback (no path module)', function() {
+  /**
+   * Verifies the pure-JS parse fallback extracts components from a POSIX path.
+   * Expected: base, ext, name, and dir are set correctly.
+   */
+  test('parses a POSIX path into correct components', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.parse('/test/dir/file.js');
+    expect(result.base).toBe('file.js');
+    expect(result.ext).toBe('.js');
+    expect(result.name).toBe('file');
+    expect(result.dir).toBe('/test/dir');
+  });
+
+  /**
+   * Verifies the pure-JS parse fallback extracts components from a Windows path.
+   * Expected: drive-letter root, dir, base, ext, and name are set correctly.
+   */
+  test('parses a Windows path into correct components', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.parse('C:\\Users\\app\\gcode.js');
+    expect(result.base).toBe('gcode.js');
+    expect(result.ext).toBe('.js');
+    expect(result.name).toBe('gcode');
+    expect(result.root).toBe('C:\\');
+  });
+
+  /**
+   * Verifies parse handles a bare filename with no directory component.
+   * Expected: dir is empty string, base equals the filename.
+   */
+  test('parses a bare filename with no directory', function() {
+    var win = loadPreload({ pathThrows: true });
+    var result = win.webviewBridge.path.parse('gcode.js');
+    expect(result.base).toBe('gcode.js');
+    expect(result.dir).toBe('');
+  });
+});
+
+describe('webview-preload — path module available (Node context)', function() {
+  /**
+   * Verifies the preload loads cleanly when Node path is available (normal
+   * Electron preload context — i.e., not the webview sandbox).
+   * Expected: module loads without throwing; webviewBridge.path.join delegates
+   * to Node path.join producing the same result as calling it directly.
+   */
+  test('loads cleanly when path module is available', function() {
+    var win;
+    expect(function() { win = loadPreload({}); }).not.toThrow();
+    // Use Node's path.join as the expected value to avoid platform assumptions.
+    var nodePath = require('path');
+    var expected = nodePath.join('/test/app', 'src', 'gcode.js');
+    var result = win.webviewBridge.path.join('/test/app', 'src', 'gcode.js');
+    expect(result).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fixes #52

## Summary
- Guard top-level require('path') in webview preload with try/catch and activate pure-JS path fallback in sandbox context
- Guard require('../ipc-channels.js') with try/catch and provide inline channel fallback for webview sandbox
- Add regression tests for both missing path and missing ipc-channels cases
- Update LEARNINGS with sandbox require behavior rule

## Validation
- npm test: 13/13 suites, 79/79 tests passing